### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [<img src="https://travis-ci.org/InfoAgeTech/django-umanage.png?branch=master">](http://travis-ci.org/InfoAgeTech/django-umanage)
 [<img src="https://coveralls.io/repos/InfoAgeTech/django-umanage/badge.png">](https://coveralls.io/r/InfoAgeTech/django-umanage)
 [<img src="https://badge.fury.io/py/django-core.png">](http://badge.fury.io/py/django-core)
-[<img src="https://pypip.in/license/django-core/badge.png">](https://github.com/InfoAgeTech/django-core/blob/master/LICENSE)
+[<img src="https://img.shields.io/pypi/l/django-core.svg">](https://github.com/InfoAgeTech/django-core/blob/master/LICENSE)
 
 
 django-umanage


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-umanage))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-umanage`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.